### PR TITLE
Add monadic operators to OptionalReference

### DIFF
--- a/include/fixed_containers/optional_reference.hpp
+++ b/include/fixed_containers/optional_reference.hpp
@@ -5,9 +5,11 @@
 #include "fixed_containers/source_location.hpp"
 
 #include <compare>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <type_traits>
+#include <utility>
 
 namespace fixed_containers
 {
@@ -142,6 +144,139 @@ public:
     {
         val() = &val;
         return val;
+    }
+
+    // C++23 monadic operations
+    template <class F>
+    constexpr auto and_then(F&& f) &
+    {
+        using Result = std::invoke_result_t<F, T&>;
+        if (has_value())
+        {
+            return std::invoke(std::forward<F>(f), **this);
+        }
+        else
+        {
+            return Result{};
+        }
+    }
+
+    template <class F>
+    constexpr auto and_then(F&& f) const &
+    {
+        using Result = std::invoke_result_t<F, const T&>;
+        if (has_value())
+        {
+            return std::invoke(std::forward<F>(f), **this);
+        }
+        else
+        {
+            return Result{};
+        }
+    }
+
+    template <class F>
+    constexpr auto and_then(F&& f) &&
+    {
+        using Result = std::invoke_result_t<F, T>;
+        if (has_value())
+        {
+            return std::invoke(std::forward<F>(f), std::move(**this));
+        }
+        else
+        {
+            return Result{};
+        }
+    }
+
+    template <class F>
+    constexpr auto and_then(F&& f) const &&
+    {
+        using Result = std::invoke_result_t<F, const T>;
+        if (has_value())
+        {
+            return std::invoke(std::forward<F>(f), std::move(**this));
+        }
+        else
+        {
+            return Result{};
+        }
+    }
+
+    template <class F>
+    constexpr auto transform(F&& f) &
+    {
+        using Result = std::remove_cv_t<std::invoke_result_t<F, T&>>;
+        if (has_value())
+        {
+            return std::optional<Result>(std::invoke(std::forward<F>(f), **this));
+        }
+        else
+        {
+            return std::optional<Result>();
+        }
+    }
+
+    template <class F>
+    constexpr auto transform(F&& f) const &
+    {
+        using Result = std::remove_cv_t<std::invoke_result_t<F, const T&>>;
+        if (has_value())
+        {
+            return std::optional<Result>(std::invoke(std::forward<F>(f), **this));
+        }
+        else
+        {
+            return std::optional<Result>();
+        }
+    }
+
+    template <class F>
+    constexpr auto transform(F&& f) &&
+    {
+        using Result = std::remove_cv_t<std::invoke_result_t<F, T>>;
+        if (has_value())
+        {
+            return std::optional<Result>(std::invoke(std::forward<F>(f), std::move(**this)));
+        }
+        else
+        {
+            return std::optional<Result>();
+        }
+    }
+
+    template <class F>
+    constexpr auto transform(F&& f) const &&
+    {
+        using Result = std::remove_cv_t<std::invoke_result_t<F, const T>>;
+        if (has_value())
+        {
+            return std::optional<Result>(std::invoke(std::forward<F>(f), std::move(**this)));
+        }
+        else
+        {
+            return std::optional<Result>();
+        }
+    }
+
+    template <std::invocable F>
+    constexpr Self or_else(F&& f) const &
+    {
+        if (has_value())
+        {
+            return *this;
+        }
+        return std::forward<F>(f)();
+    }
+
+    template <std::invocable F>
+    constexpr Self or_else(F&& f) &&
+    {
+        if (has_value())
+        {
+            return std::move(*this);
+        }
+        return std::forward<F>(f)();
     }
 
 private:

--- a/test/optional_reference_test.cpp
+++ b/test/optional_reference_test.cpp
@@ -415,4 +415,50 @@ TEST(OptionalReference, ConstHandling)
     }
 }
 
+TEST(OptionalReference, AndThen)
+{
+    int val = 7;
+    OptionalReference<int> opt{val};
+    auto r = opt.and_then([](int& v) { return OptionalReference<int>(v); });
+    static_assert(std::is_same_v<decltype(r), OptionalReference<int>>);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(&r.value(), &val);
+
+    OptionalReference<int> empty{};
+    bool called = false;
+    auto r2 = empty.and_then([&](int&) {
+        called = true;
+        return OptionalReference<int>{};
+    });
+    EXPECT_FALSE(called);
+    EXPECT_FALSE(r2.has_value());
+}
+
+TEST(OptionalReference, Transform)
+{
+    int val = 3;
+    OptionalReference<int> opt{val};
+    auto r = opt.transform([](int& v) { return v * 2; });
+    static_assert(std::is_same_v<decltype(r), std::optional<int>>);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(*r, 6);
+
+    OptionalReference<int> empty{};
+    auto r2 = empty.transform([](int& v) { return v * 2; });
+    EXPECT_FALSE(r2.has_value());
+}
+
+TEST(OptionalReference, OrElse)
+{
+    int primary = 1;
+    int secondary = 2;
+    OptionalReference<int> opt{primary};
+    auto r = opt.or_else([&]() { return OptionalReference<int>(secondary); });
+    EXPECT_EQ(&r.value(), &primary);
+
+    OptionalReference<int> empty{};
+    auto r2 = empty.or_else([&]() { return OptionalReference<int>(secondary); });
+    EXPECT_EQ(&r2.value(), &secondary);
+}
+
 }  // namespace fixed_containers


### PR DESCRIPTION
## Summary
- add `<functional>` and `<utility>` includes
- implement `and_then`, `transform`, and `or_else`
- test new monadic operators

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "magic_enum")*
- `bazel test :all_tests` *(fails to fetch remote resources due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68671535adb883248a17cc44c6e00be3